### PR TITLE
feat: Add id inference

### DIFF
--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -22,6 +22,7 @@ import {
   LayoutFn,
   Id,
 } from "./scenegraph";
+import { IdContext } from "./withBluefish";
 
 export type LayoutProps = ParentProps<{
   id: Id;
@@ -54,19 +55,21 @@ export const Layout: Component<LayoutProps> = (props) => {
   // h/t Erik Demaine
   const jsx = (
     <ParentIDContext.Provider value={props.id}>
-      <Dynamic
-        component={props.paint}
-        bbox={scenegraph[props.id]?.bbox ?? {}}
-        transform={{
-          translate: {
-            x: scenegraph[props.id]?.transform?.translate?.x ?? 0,
-            y: scenegraph[props.id]?.transform?.translate?.y ?? 0,
-          },
-        }}
-        customData={scenegraph[props.id]?.customData}
-      >
-        {props.children}
-      </Dynamic>
+      <IdContext.Provider value={() => undefined}>
+        <Dynamic
+          component={props.paint}
+          bbox={scenegraph[props.id]?.bbox ?? {}}
+          transform={{
+            translate: {
+              x: scenegraph[props.id]?.transform?.translate?.x ?? 0,
+              y: scenegraph[props.id]?.transform?.translate?.y ?? 0,
+            },
+          }}
+          customData={scenegraph[props.id]?.customData}
+        >
+          {props.children}
+        </Dynamic>
+      </IdContext.Provider>
     </ParentIDContext.Provider>
   );
 

--- a/src/stories/IdInference.stories.tsx
+++ b/src/stories/IdInference.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryObj } from "storybook-solidjs";
+import Bluefish from "../bluefish";
+import Group from "../group";
+import Rect from "../rect";
+import Ref from "../ref";
+import withBluefish from "../withBluefish";
+import { Row } from "../row";
+import { Col } from "../col";
+
+const meta: Meta = {
+  title: "Feat/Id Inference",
+};
+
+export default meta;
+type Story = StoryObj;
+
+const CustomComponent = withBluefish(() => {
+  return <Rect width={100} height={20} />;
+});
+
+export const App: Story = {
+  name: "Id Inference",
+  render: () => {
+    return (
+      <Bluefish>
+        <Group x={0} y={0}>
+          <Row>
+            <Rect width={200} height={20} fill="blue" x={0} />
+            <CustomComponent id="custom" />
+          </Row>
+          <Col>
+            <Ref refId="custom" />
+            <Rect width={100} height={20} fill="magenta" />
+          </Col>
+        </Group>
+      </Bluefish>
+    );
+  },
+};

--- a/src/stories/SimpleTree.stories.tsx
+++ b/src/stories/SimpleTree.stories.tsx
@@ -30,7 +30,7 @@ const Node = withBluefish((props: NodeProps) => {
   const nodeOutlineId = `${props.id}_outline`;
 
   return (
-    <Group id={props.id}>
+    <Group>
       <Rect
         id={nodeOutlineId}
         width={50}
@@ -88,7 +88,7 @@ const Tree = withBluefish((props: TreeProps) => {
   );
 
   return (
-    <Group id={props.id}>
+    <Group>
       <Node id={data.nodeId} nodeValue={data.nodeValue} />
 
       {data.subtrees?.length ? (

--- a/src/withBluefish.tsx
+++ b/src/withBluefish.tsx
@@ -1,21 +1,38 @@
-import { Component, JSX, createUniqueId, mergeProps } from "solid-js";
+import {
+  Accessor,
+  Component,
+  JSX,
+  createContext,
+  createUniqueId,
+  mergeProps,
+  useContext,
+} from "solid-js";
 import { Id } from "./scenegraph";
 
-export type WithBluefishProps<T = {}> = T & {
+export type WithBluefishProps<T = object> = T & {
   id: Id;
 };
+
+export const IdContext = createContext<Accessor<Id | undefined>>(
+  () => undefined
+);
 
 export function withBluefish<ComponentProps>(
   WrappedComponent: Component<WithBluefishProps<ComponentProps>>
 ) {
   return function (props: Omit<ComponentProps, "id"> & { id?: Id }) {
-    const id = createUniqueId();
-    const mergedProps = mergeProps(
-      { id },
-      props
-    ) as WithBluefishProps<ComponentProps>;
+    const contextId = useContext(IdContext);
+    const genId = createUniqueId();
+    const id = () => props.id ?? contextId() ?? genId;
 
-    return <WrappedComponent {...mergedProps} />;
+    return (
+      <IdContext.Provider value={id}>
+        <WrappedComponent
+          {...(props as WithBluefishProps<ComponentProps>)}
+          id={id()}
+        />
+      </IdContext.Provider>
+    );
   };
 }
 


### PR DESCRIPTION
Previously, a user would have to pass the id prop explicitly through a custom component to its child:

```tsx
const CustomComponent = withBluefish((props) => {
  return <Group id={props.id} ... > ... </Group>
})
```

This PR adds id inference so that the id can be left out.
```tsx
const CustomComponent = withBluefish((props) => {
  return <Group ... > ... </Group>
})
```