### PR TITLE
Create Python Tutor Example in Storybook

### DIFF
--- a/src/arrow.tsx
+++ b/src/arrow.tsx
@@ -135,6 +135,7 @@ export const Arrow = withBluefish((props: ArrowProps) => {
               cx={paintProps.customData.sx}
               cy={paintProps.customData.sy}
               r={4}
+              fill={props.stroke}
             />
           </Show>
           <path

--- a/src/arrow.tsx
+++ b/src/arrow.tsx
@@ -20,6 +20,7 @@ export type ArrowProps = ParentProps<
     y?: number;
     start?: boolean;
     "stroke-width"?: number;
+    stroke?: string;
   } & ArrowOptions
 >;
 
@@ -35,6 +36,7 @@ export const Arrow = withBluefish((props: ArrowProps) => {
       flip: false,
       straights: true,
       "stroke-width": 3,
+      stroke: "black",
     },
     props
   );
@@ -138,7 +140,7 @@ export const Arrow = withBluefish((props: ArrowProps) => {
           <path
             d={`M${paintProps.customData.sx},${paintProps.customData.sy} Q${paintProps.customData.cx},${paintProps.customData.cy} ${paintProps.customData.ex},${paintProps.customData.ey}`}
             fill="none"
-            stroke="black"
+            stroke={props.stroke}
             stroke-width={props["stroke-width"]}
           />
           <polygon
@@ -146,6 +148,7 @@ export const Arrow = withBluefish((props: ArrowProps) => {
             transform={`translate(${paintProps.customData.ex},${
               paintProps.customData.ey
             }) rotate(${endAngleAsDegrees()})`}
+            fill={props.stroke}
           />
           {paintProps.children}
         </g>

--- a/src/arrow.tsx
+++ b/src/arrow.tsx
@@ -134,7 +134,7 @@ export const Arrow = withBluefish((props: ArrowProps) => {
             <circle
               cx={paintProps.customData.sx}
               cy={paintProps.customData.sy}
-              r={4}
+              r={(4 / 3) * props["stroke-width"]!}
               fill={props.stroke}
             />
           </Show>

--- a/src/python-tutor/elm-tuple.tsx
+++ b/src/python-tutor/elm-tuple.tsx
@@ -1,0 +1,71 @@
+import { createUniqueId } from "solid-js";
+import { Align } from "../../src/align";
+import { Group } from "../../src/group";
+import { Rect } from "../../src/rect";
+import { Ref } from "../../src/ref";
+import { Id } from "../../src/scenegraph";
+import { Text } from "../../src/text";
+import { Value } from "./types";
+
+export type ElmTupleProps = {
+  x?: number;
+  y?: number;
+  id?: Id;
+  tupleIndex: string;
+  tupleData: { type: string; value: Value };
+  objectId: string;
+};
+
+export function ElmTuple(props: ElmTupleProps) {
+  const id = createUniqueId();
+  const fontFamily = "verdana, arial, helvetica, sans-serif";
+
+  return (
+    <Group
+      id={props.id ?? `elm_${props.tupleIndex}_${props.objectId}`}
+      x={props.x}
+      y={props.y}
+    >
+      <Rect
+        id={`elmBox_${props.tupleIndex}_${props.objectId}`}
+        height={60}
+        width={70}
+        fill={"#ffffc6"}
+        stroke={"grey"}
+      />
+      <Text
+        id={`elmLabel_${props.tupleIndex}_${props.objectId}`}
+        font-family={fontFamily}
+        font-size={"16px"}
+        fill={"gray"}
+      >
+        {props.tupleIndex}
+      </Text>
+
+      {props.tupleData.type === "string" ? (
+        <Text
+          id={`elmVal_${props.tupleIndex}_${props.objectId}`}
+          font-size={"24px"}
+          font-family={fontFamily}
+          fill={"black"}
+        >
+          {props.tupleData.value as string}
+        </Text>
+      ) : (
+        <Text id={`elmVal_${props.tupleIndex}_${props.objectId}`} fill={"none"}>
+          {""}
+        </Text>
+      )}
+      <Align alignment="center">
+        <Ref refId={`elmVal_${props.tupleIndex}_${props.objectId}`} />
+        <Ref refId={`elmBox_${props.tupleIndex}_${props.objectId}`} />
+      </Align>
+      <Align alignment="topLeft">
+        <Ref refId={`elmLabel_${props.tupleIndex}_${props.objectId}`} />
+        <Ref refId={`elmBox_${props.tupleIndex}_${props.objectId}`} />
+      </Align>
+    </Group>
+  );
+}
+
+export default ElmTuple;

--- a/src/python-tutor/global-frame.tsx
+++ b/src/python-tutor/global-frame.tsx
@@ -1,0 +1,78 @@
+import { For, createUniqueId } from "solid-js";
+import { Id } from "../../src/scenegraph";
+import Rect from "../../src/rect";
+import Group from "../../src/group";
+import Align from "../../src/align";
+import Ref from "../../src/ref";
+import { StackSlot } from "./stack-slot";
+import Distribute from "../../src/distribute";
+import Text from "../../src/text";
+import { Value } from "./types";
+
+export type GlobalFrameProps = {
+  id?: Id;
+  variables: { variable: string; value: Value }[];
+};
+
+export function GlobalFrame(props: GlobalFrameProps) {
+  const id = props.id ?? createUniqueId();
+
+  // Font declaration
+  const fontFamily = "Andale mono, monospace";
+
+  return (
+    <Group x={0} y={0} id={props.id ?? `group_${id}`}>
+      {/* Global Frame and relevant text */}
+      <Rect id={`frame${id}`} height={300} width={200} fill={"#e2ebf6"} />
+      <Rect id={`frameBorder${id}`} height={300} width={5} fill={"#a6b3b6"} />
+      {/* TODO: there is a bug where the text is showing up lower than I expect it to... */}
+      <Text
+        id={`label${id}`}
+        font-size={"24px"}
+        font-family={fontFamily}
+        fill={"black"}
+      >
+        Global Frame
+      </Text>
+      <Align alignment="topCenter">
+        <Ref refId={`label${id}`} />
+        <Ref refId={`frame${id}`} />
+      </Align>
+      <Align alignment="centerLeft">
+        <Ref refId={`frameBorder${id}`} />
+        <Ref refId={`frame${id}`} />
+      </Align>
+      <Group id={`frameVariables${id}`}>
+        <For each={props.variables}>
+          {(variable: any, i) => (
+            <StackSlot
+              id={`stackSlot${i()}_${id}`}
+              variable={variable.variable}
+              value={variable.value}
+            />
+          )}
+        </For>
+        <Align alignment="right">
+          <For each={props.variables}>
+            {(variable: any, i) => <Ref refId={`stackSlot${i()}_${id}`} />}
+          </For>
+        </Align>
+        <Distribute direction="vertical" spacing={10}>
+          <For each={props.variables}>
+            {(variable: any, i) => <Ref refId={`stackSlot${i()}_${id}`} />}
+          </For>
+        </Distribute>
+      </Group>
+      <Distribute direction="vertical" spacing={10}>
+        <Ref refId={`label${id}`} />
+        <Ref refId={`frameVariables${id}`} />
+      </Distribute>
+      <Align alignment="right">
+        <Ref refId={`frameVariables${id}`} />
+        <Ref refId={`label${id}`} />
+      </Align>
+    </Group>
+  );
+}
+
+export default GlobalFrame;

--- a/src/python-tutor/heap-object.tsx
+++ b/src/python-tutor/heap-object.tsx
@@ -1,0 +1,72 @@
+import Group from "../../src/group";
+import Text from "../../src/text";
+import { Id } from "../../src/scenegraph";
+import Distribute from "../../src/distribute";
+import Ref from "../../src/ref";
+import Align from "../../src/align";
+import { For, createUniqueId } from "solid-js";
+import ElmTuple from "./elm-tuple";
+import withBluefish from "../../src/withBluefish";
+import { Value } from "./types";
+
+export type ObjectProps = {
+  id: Id;
+  objectType: string;
+  objectValues: {
+    type: string;
+    value: Value;
+  }[];
+};
+
+export const HeapObject = withBluefish((props: ObjectProps) => {
+  const id = () => props.id;
+
+  const fontFamily = "verdana, arial, helvetica, sans-serif";
+
+  const objectRef = `objectRef${id()}`;
+
+  return (
+    <Group id={id()}>
+      <Text
+        id={`objectTypeRef${id()}`}
+        font-family={fontFamily}
+        font-size={"16px"}
+        fill={"grey"}
+      >
+        {props.objectType}
+      </Text>
+      <Group id={objectRef}>
+        <For each={props.objectValues}>
+          {(elementData, index) => (
+            <ElmTuple
+              id={`elm_${index()}_${id()}`}
+              tupleIndex={`${index()}`}
+              tupleData={elementData}
+              objectId={id()}
+            />
+          )}
+        </For>
+        <Align alignment="centerY">
+          <For each={props.objectValues}>
+            {(elementData, index) => <Ref refId={`elm_${index()}_${id()}`} />}
+          </For>
+        </Align>
+        <Distribute direction="horizontal" spacing={0}>
+          <For each={props.objectValues}>
+            {(elementData, index) => <Ref refId={`elm_${index()}_${id()}`} />}
+          </For>
+        </Distribute>
+      </Group>
+      <Distribute direction={"vertical"} spacing={10}>
+        <Ref refId={`objectTypeRef${id()}`} />
+        <Ref refId={objectRef} />
+      </Distribute>
+      <Align alignment={"left"}>
+        <Ref refId={`objectTypeRef${id()}`} />
+        <Ref refId={objectRef} />
+      </Align>
+    </Group>
+  );
+});
+
+export default HeapObject;

--- a/src/python-tutor/heap.tsx
+++ b/src/python-tutor/heap.tsx
@@ -100,7 +100,13 @@ export const Heap = withBluefish((props: HeapProps) => {
                 )}`;
                 if (fromId !== undefined && toId !== undefined) {
                   return (
-                    <Arrow bow={0} padEnd={25} stroke="#1A5683" start>
+                    <Arrow
+                      bow={0}
+                      padEnd={25}
+                      stroke="#1A5683"
+                      start
+                      padStart={0}
+                    >
                       <Ref refId={fromId} />
                       <Ref refId={toId} />
                     </Arrow>

--- a/src/python-tutor/heap.tsx
+++ b/src/python-tutor/heap.tsx
@@ -100,7 +100,7 @@ export const Heap = withBluefish((props: HeapProps) => {
                 )}`;
                 if (fromId !== undefined && toId !== undefined) {
                   return (
-                    <Arrow bow={0} padEnd={25} stroke="#1A5683">
+                    <Arrow bow={0} padEnd={25} stroke="#1A5683" start>
                       <Ref refId={fromId} />
                       <Ref refId={toId} />
                     </Arrow>

--- a/src/python-tutor/heap.tsx
+++ b/src/python-tutor/heap.tsx
@@ -1,0 +1,118 @@
+import { For } from "solid-js";
+import { Align } from "../../src/align";
+import { Distribute } from "../../src/distribute";
+import { Group } from "../../src/group";
+import { Rect } from "../../src/rect";
+import { Arrow } from "../../src/arrow";
+import { Ref } from "../../src/ref";
+import { Id } from "../../src/scenegraph";
+import withBluefish from "../../src/withBluefish";
+import { HeapObject } from "./heap-object";
+import { Address, HeapObject as HeapObjectType, formatValue } from "./types";
+
+export type HeapProps = {
+  id: Id;
+  heap: HeapObjectType[];
+  heapArrangement: (Address | null)[][];
+};
+
+export const Heap = withBluefish((props: HeapProps) => {
+  // Maps object number to the ID of the corresponding heap object
+  // This will help generate Arrows between objects
+  const objectIdToComponentId = new Map<number, string>();
+  props.heapArrangement.forEach((row, rowIndex) => {
+    row.forEach((obj, colIndex) => {
+      if (obj !== null) {
+        objectIdToComponentId.set(obj, `row${rowIndex}_col${colIndex}`);
+      }
+    });
+  });
+
+  return (
+    <Group id={props.id}>
+      <For each={props.heapArrangement}>
+        {(row, index) => (
+          <Group id={`row${index()}~${props.id}`}>
+            <For each={row}>
+              {(obj, objIndex) =>
+                obj === null ? (
+                  <Rect
+                    id={`row${index()}_col${objIndex()}`}
+                    height={60}
+                    width={140}
+                    fill={"none"}
+                    stroke={"none"}
+                  />
+                ) : (
+                  <HeapObject
+                    id={`row${index()}_col${objIndex()}`}
+                    objectType={props.heap[obj].type}
+                    objectValues={props.heap[obj].values.map((value) => ({
+                      type: typeof value === "string" ? "string" : "pointer",
+                      value: formatValue(value),
+                    }))}
+                  />
+                )
+              }
+            </For>
+            <Distribute direction="horizontal" spacing={75}>
+              <For each={row}>
+                {(obj, objIndex) => (
+                  <Ref refId={`row${index()}_col${objIndex()}`} />
+                )}
+              </For>
+            </Distribute>
+            <Align alignment="bottom">
+              <For each={row}>
+                {(obj, objIndex) => (
+                  <Ref refId={`row${index()}_col${objIndex()}`} />
+                )}
+              </For>
+            </Align>
+          </Group>
+        )}
+      </For>
+      <Distribute direction="vertical" spacing={75}>
+        <For each={props.heapArrangement}>
+          {(row, index) => <Ref refId={`row${index()}~${props.id}`} />}
+        </For>
+      </Distribute>
+      <Align alignment="left">
+        <For each={props.heapArrangement}>
+          {(row, index) => <Ref refId={`row${index()}~${props.id}`} />}
+        </For>
+      </Align>
+
+      {/* Add arrows between heap objects */}
+      <For each={props.heap}>
+        {(heapObject, heapObIndex) => (
+          <For each={heapObject.values}>
+            {(elmTupleValue, elmTupleIndex) => {
+              if (
+                typeof elmTupleValue !== "string" &&
+                typeof elmTupleValue !== "number"
+              ) {
+                const fromId = `elmVal_${elmTupleIndex()}_${objectIdToComponentId.get(
+                  heapObIndex()
+                )}`;
+                const toId = `elm_0_${objectIdToComponentId.get(
+                  elmTupleValue.value
+                )}`;
+                if (fromId !== undefined && toId !== undefined) {
+                  return (
+                    <Arrow bow={0} padEnd={25} stroke="#1A5683">
+                      <Ref refId={fromId} />
+                      <Ref refId={toId} />
+                    </Arrow>
+                  );
+                }
+              }
+            }}
+          </For>
+        )}
+      </For>
+    </Group>
+  );
+});
+
+export default Heap;

--- a/src/python-tutor/stack-slot.tsx
+++ b/src/python-tutor/stack-slot.tsx
@@ -1,0 +1,81 @@
+import Group from "../../src/group";
+import Rect from "../../src/rect";
+import Align from "../../src/align";
+import Distribute from "../../src/distribute";
+import Ref from "../../src/ref";
+import Text from "../../src/text";
+import { createUniqueId } from "solid-js";
+import { Id } from "../../src/scenegraph";
+import { Pointer } from "./types";
+
+export type StackSlotProps = {
+  id?: Id;
+  variable: string;
+  value: string | Pointer;
+};
+
+export function StackSlot(props: StackSlotProps) {
+  const id = props.id ?? `stackSlot_${createUniqueId()}`;
+
+  const fontFamily = "verdana, arial, helvetica, sans-serif";
+
+  return (
+    <Group id={id}>
+      <Rect id={`box_${id}`} y={0} height={40} width={40} fill={"#e2ebf6"} />
+      <Text id={`name_${id}`} font-size={"24px"} font-family={fontFamily}>
+        {props.variable}
+      </Text>
+      {/* TODO: if we only align or distribute on a single dimension, then their bounding boxes should be null or something along the unconstrained dimension... */}
+      <Align alignment="centerY">
+        <Ref refId={`name_${id}`} />
+        <Ref refId={`box_${id}`} />
+      </Align>
+      <Distribute direction="horizontal" spacing={5}>
+        <Ref refId={`name_${id}`} />
+        <Ref refId={`box_${id}`} />
+      </Distribute>
+      <Align alignment="bottomCenter">
+        <Rect
+          id={`boxBorderBottom${id}`}
+          height={2}
+          width={40}
+          fill={"#a6b3b6"}
+        />
+        <Ref refId={`box_${id}`} />
+      </Align>
+      <Align alignment="centerLeft">
+        <Rect
+          id={`boxBorderLeft${id}`}
+          height={40}
+          width={2}
+          fill={"#a6b3b6"}
+        />
+        <Ref refId={`box_${id}`} />
+      </Align>
+
+      {typeof props.value === "string" ? (
+        <Align alignment="center">
+          <Text
+            id={`valueName_${id}`}
+            font-size="24px"
+            font-family={fontFamily}
+          >
+            {props.value}
+          </Text>
+          <Ref refId={`box_${id}`} />
+        </Align>
+      ) : (
+        <Align alignment="center">
+          <Text
+            id={`valueName_${id}`}
+            font-size="24px"
+            font-family={fontFamily}
+          >
+            {""}
+          </Text>
+          <Ref refId={`box_${id}`} />
+        </Align>
+      )}
+    </Group>
+  );
+}

--- a/src/python-tutor/types.tsx
+++ b/src/python-tutor/types.tsx
@@ -1,0 +1,38 @@
+export type Address = number;
+
+export type Pointer = { type: "pointer"; value: Address };
+
+export const pointer = (value: Address): Pointer => ({
+  type: "pointer",
+  value,
+});
+
+export type Value = string | number | Pointer;
+
+export type StackSlot = {
+  variable: string;
+  value: Value;
+};
+
+export const formatValue = (value: Value): string | number => {
+  let formattedValue: string | number;
+  if (typeof value === "string" || typeof value === "number") {
+    formattedValue = `${value}`;
+  } else {
+    formattedValue = value.value;
+  }
+  return formattedValue;
+};
+
+export const stackSlot = (variable: string, value: Value): StackSlot => {
+  return {
+    variable,
+    value: value,
+  };
+};
+
+export type Tuple = { type: "tuple"; values: Value[] };
+
+export const tuple = (values: Value[]): Tuple => ({ type: "tuple", values });
+
+export type HeapObject = Tuple;

--- a/src/stories/PythonTutor.stories.tsx
+++ b/src/stories/PythonTutor.stories.tsx
@@ -60,7 +60,7 @@ const PythonTutor = withBluefish((props: PythonTutorProps) => {
         {(stackSlot, slackSlotIndex) =>
           typeof stackSlot.value !== "string" &&
           typeof stackSlot.value !== "number" ? (
-            <Arrow bow={0} stretch={0} flip stroke="#1A5683" start>
+            <Arrow bow={0} stretch={0} flip stroke="#1A5683" padStart={0} start>
               <Ref
                 refId={`valueName_stackSlot${slackSlotIndex()}_globalFrame-${
                   props.id

--- a/src/stories/PythonTutor.stories.tsx
+++ b/src/stories/PythonTutor.stories.tsx
@@ -1,3 +1,5 @@
+// Examples created based on Python Tutor: https://pythontutor.com/
+
 import type { Meta, StoryObj } from "storybook-solidjs";
 import { Bluefish } from "../bluefish";
 import { Align } from "../align";
@@ -58,7 +60,7 @@ const PythonTutor = withBluefish((props: PythonTutorProps) => {
         {(stackSlot, slackSlotIndex) =>
           typeof stackSlot.value !== "string" &&
           typeof stackSlot.value !== "number" ? (
-            <Arrow bow={0} stretch={0} flip stroke="#1A5683">
+            <Arrow bow={0} stretch={0} flip stroke="#1A5683" start>
               <Ref
                 refId={`valueName_stackSlot${slackSlotIndex()}_globalFrame-${
                   props.id

--- a/src/stories/PythonTutor.stories.tsx
+++ b/src/stories/PythonTutor.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from "storybook-solidjs";
+import { Bluefish } from "../bluefish";
+import { Align } from "../align";
+import { Arrow } from "../arrow";
+import { Distribute } from "../distribute";
+import { Group } from "../group";
+import { Ref } from "../ref";
+import { withBluefish, WithBluefishProps } from "../withBluefish";
+import { GlobalFrame } from "../python-tutor/global-frame";
+import { Heap } from "../python-tutor/heap";
+import { Address, HeapObject, StackSlot } from "../python-tutor/types";
+import { For } from "solid-js";
+
+const meta: Meta = {
+  title: "Example/PythonTutor",
+};
+
+export default meta;
+type Story = StoryObj;
+
+type PythonTutorProps = WithBluefishProps<{
+  stack: StackSlot[];
+  heap: HeapObject[];
+  heapArrangement: (Address | null)[][];
+}>;
+
+const PythonTutor = withBluefish((props: PythonTutorProps) => {
+  // Maps object number to the ID of the corresponding heap object
+  // This will help generate Arrows between objects
+  const objectIdToComponentId = new Map<number, string>();
+  props.heapArrangement.forEach((row, rowIndex) => {
+    row.forEach((obj, colIndex) => {
+      if (obj !== null) {
+        objectIdToComponentId.set(obj, `row${rowIndex}_col${colIndex}`);
+      }
+    });
+  });
+
+  return (
+    <Group id={props.id}>
+      <GlobalFrame id={`globalFrame-${props.id}`} variables={props.stack} />
+      <Heap
+        id={`heap-${props.id}`}
+        heap={props.heap}
+        heapArrangement={props.heapArrangement}
+      />
+      <Distribute direction="horizontal" spacing={60}>
+        <Ref refId={`globalFrame-${props.id}`} />
+        <Ref refId={`heap-${props.id}`} />
+      </Distribute>
+      <Align alignment="top">
+        <Ref refId={`globalFrame-${props.id}`} />
+        <Ref refId={`heap-${props.id}`} />
+      </Align>
+
+      {/* Make arrows from stack slots to heap objects */}
+      <For each={props.stack}>
+        {(stackSlot, slackSlotIndex) =>
+          typeof stackSlot.value !== "string" &&
+          typeof stackSlot.value !== "number" ? (
+            <Arrow bow={0} stretch={0} flip stroke="#1A5683">
+              <Ref
+                refId={`valueName_stackSlot${slackSlotIndex()}_globalFrame-${
+                  props.id
+                }`}
+              />
+              <Ref
+                refId={`elm_0_${objectIdToComponentId.get(
+                  stackSlot.value.value
+                )}`}
+              />
+            </Arrow>
+          ) : null
+        }
+      </For>
+    </Group>
+  );
+});
+
+export const PythonTutorExample: Story = {
+  args: {
+    id: "pt0",
+    stack: [
+      { variable: "c", value: { type: "pointer", value: 0 } },
+      { variable: "d", value: { type: "pointer", value: 1 } },
+      { variable: "x", value: "5" },
+    ],
+    heap: [
+      {
+        type: "tuple",
+        values: [
+          "1",
+          { type: "pointer", value: 1 },
+          { type: "pointer", value: 2 },
+        ],
+      },
+      { type: "tuple", values: ["1", "4"] },
+      { type: "tuple", values: ["3", "10"] },
+    ],
+    heapArrangement: [
+      [0, null, null],
+      [null, 1, 2],
+    ],
+  },
+  render: (props) => (
+    <Bluefish>
+      <PythonTutor
+        {...props}
+        heap={props.heap}
+        heapArrangement={props.heapArrangement}
+        stack={props.stack}
+      />
+    </Bluefish>
+  ),
+};

--- a/src/stories/SimpleTree.stories.tsx
+++ b/src/stories/SimpleTree.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from "storybook-solidjs";
+import { Bluefish } from "../bluefish";
+import { For, createUniqueId, mergeProps } from "solid-js";
+import withBluefish, { WithBluefishProps } from "../withBluefish";
+import { Group } from "../group";
+import { Rect } from "../rect";
+import { Ref } from "../ref";
+import { Text } from "../text";
+import { Col } from "../col";
+import { Row } from "../row";
+import { Arrow } from "../arrow";
+import { Align } from "../align";
+
+const meta: Meta = {
+  title: "Example/SimpleTree",
+};
+
+export default meta;
+type Story = StoryObj;
+
+// Component to render Tree node
+type NodeProps = WithBluefishProps<{
+  nodeValue: string;
+  id?: string;
+}>;
+
+const Node = withBluefish((props: NodeProps) => {
+  props = mergeProps({ nodeValue: "?", id: createUniqueId() }, props);
+  const nodeValueId = `${props.id}_value`;
+  const nodeOutlineId = `${props.id}_outline`;
+
+  return (
+    <Group id={props.id}>
+      <Rect
+        id={nodeOutlineId}
+        width={50}
+        height={65}
+        rx={5}
+        fill={"cornflowerblue"}
+        stroke={"black"}
+        opacity={0.5}
+      />
+      <Text id={nodeValueId} font-size="24px">
+        {props.nodeValue}
+      </Text>
+      <Align alignment="centerY">
+        <Ref refId={nodeValueId} />
+        <Ref refId={nodeOutlineId} />
+      </Align>
+      <Align alignment="centerX">
+        <Ref refId={nodeValueId} />
+        <Ref refId={nodeOutlineId} />
+      </Align>
+    </Group>
+  );
+});
+
+// Component to render Tree
+type TreeData = {
+  subtrees?: TreeData[];
+  nodeId?: string;
+  nodeValue?: string;
+};
+
+type TreeProps = WithBluefishProps<{
+  data: TreeData;
+}>;
+
+const Tree = withBluefish((props: TreeProps) => {
+  // merge props.data with default
+  props.data = mergeProps(
+    {
+      subtrees: [] as TreeData[],
+      nodeId: createUniqueId(),
+      nodeValue: "?",
+    },
+    props.data
+  );
+
+  // merge props with default
+  props = mergeProps({ id: createUniqueId() }, props);
+
+  const data = props.data;
+  const subtreeRowId = `subtrees_of_${data.nodeId}`;
+
+  let subtreeIds: string[] = data.subtrees.map(
+    (subtree) => `${subtree.nodeId}_subtree`
+  );
+
+  return (
+    <Group id={props.id}>
+      <Node id={data.nodeId} nodeValue={data.nodeValue} />
+
+      {data.subtrees?.length ? (
+        <>
+          <Col spacing={50} alignment="centerX">
+            <Ref refId={data.nodeId} />
+            <Row id={subtreeRowId} alignment="centerY" spacing={50}>
+              <For each={data.subtrees}>
+                {(child, i) => <Tree id={subtreeIds[i()]} data={child} />}
+              </For>
+            </Row>
+          </Col>
+          <For each={data.subtrees}>
+            {(child, i) => (
+              <Arrow bow={0} stretch={0.1} flip>
+                <Ref refId={data.nodeId} />
+                <Ref refId={child.nodeId} />
+              </Arrow>
+            )}
+          </For>
+        </>
+      ) : null}
+    </Group>
+  );
+});
+
+export const TwoLevelTree: Story = {
+  args: {
+    id: "tree0",
+    data: {
+      nodeId: "node0",
+      nodeValue: "A",
+      subtrees: [
+        { nodeValue: "B", nodeId: "node1" },
+        { nodeValue: "C", nodeId: "node2" },
+      ],
+    },
+  },
+  render: (props) => (
+    <Bluefish width={500} height={500}>
+      <Tree {...props} data={props.data} />
+    </Bluefish>
+  ),
+};
+
+export const ThreeLevelTree: Story = {
+  args: {
+    id: "tree1",
+    data: {
+      nodeId: "node0",
+      nodeValue: "A",
+      subtrees: [
+        {
+          nodeValue: "B",
+          nodeId: "node1",
+          subtrees: [
+            { nodeId: "node3", nodeValue: "D" },
+            { nodeId: "node4", nodeValue: "E" },
+          ],
+        },
+        {
+          nodeValue: "C",
+          nodeId: "node2",
+          subtrees: [
+            { nodeId: "node5", nodeValue: "F" },
+            { nodeId: "node6", nodeValue: "G" },
+          ],
+        },
+      ],
+    },
+  },
+  render: (props) => (
+    <Bluefish width={500} height={500}>
+      <Tree {...props} data={props.data} />
+    </Bluefish>
+  ),
+};


### PR DESCRIPTION
Created a Python Tutor example, which displays as follows in storybook:
<img width="867" alt="image" src="https://github.com/bluefishjs/rockfish/assets/55002606/2ffefa72-830f-4415-a076-79e635dbb0d2">

The following files were added under the folder at path: `src/python-tutor`
* `elm-tuple.tsx`
* `heap-object.tsx`
* `heap.tsx`
* `stack-slot.tsx`
* `global-frame.tsx`
* `types.tsx`

These files contain sub-components of the Python Tutor diagram and are imported in the storybook file (which contains the actual Python Tutor component)

This PR also includes small addition to the Arrow component to control the color of the arrows.