### PR TITLE
fix: add error context to deleteNode

### DIFF
--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -18,6 +18,7 @@ import {
 } from "./scenegraph";
 import { IdContext } from "./withBluefish";
 import { ScopeContext } from "./createName";
+import { useError } from "./errorContext";
 
 export type LayoutProps = ParentProps<{
   name: Id;
@@ -34,6 +35,7 @@ export type LayoutProps = ParentProps<{
 export const Layout: Component<LayoutProps> = (props) => {
   const parentId = useContext(ParentIDContext);
   const [_scope, setScope] = useContext(ScopeContext);
+  const error = useError();
 
   const { scenegraph, createNode, deleteNode, setLayout } =
     UNSAFE_useScenegraph();
@@ -43,7 +45,7 @@ export const Layout: Component<LayoutProps> = (props) => {
   });
 
   onCleanup(() => {
-    deleteNode(props.name, setScope);
+    deleteNode(error, props.name, setScope);
   });
 
   // evaluate the child props before running the effect so that children's layout functions are

--- a/src/scenegraph.ts
+++ b/src/scenegraph.ts
@@ -132,9 +132,11 @@ export const createScenegraph = (): ScenegraphContextType => {
     }
   };
 
-  const deleteNode = (id: Id, setScope: SetStoreFunction<Scope>) => {
-    const error = useError();
-
+  const deleteNode = (
+    error: (error: BluefishError) => void,
+    id: Id,
+    setScope: SetStoreFunction<Scope>
+  ) => {
     const node = scenegraph[id];
 
     if (node === undefined) {
@@ -969,7 +971,11 @@ the align node.
 export type ScenegraphContextType = {
   scenegraph: Scenegraph;
   createNode: (id: Id, parentId: Id | null) => void;
-  deleteNode: (id: Id, setScope: SetStoreFunction<Scope>) => void;
+  deleteNode: (
+    error: (error: BluefishError) => void,
+    id: Id,
+    setScope: SetStoreFunction<Scope>
+  ) => void;
   createRef: (id: Id, refId: Id, parentId: Id) => void;
   deleteRef: (error: (error: BluefishError) => void, id: Id) => void;
   resolveRef: (


### PR DESCRIPTION
addresses context issues encountered sporadically when recompiling and also faced in #60 reliably